### PR TITLE
chore: bump package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@aculab-com/react-native-aculab-client",
-  "version": "1.5.2-beta",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aculab-com/react-native-aculab-client",
-      "version": "1.5.2-beta",
+      "version": "1.5.3",
       "license": "MIT",
       "dependencies": {
-        "@aculab-com/aculab-webrtc": "^4.0.0-beta",
+        "@aculab-com/aculab-webrtc": "^4.0.1",
         "react-native-base64": "^0.2.1",
         "react-native-webrtc": "^106.0.6"
       },
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@aculab-com/aculab-webrtc": {
-      "version": "4.0.0-beta",
-      "resolved": "https://registry.npmjs.org/@aculab-com/aculab-webrtc/-/aculab-webrtc-4.0.0-beta.tgz",
-      "integrity": "sha512-esAFbKGn1Vq5RTs5Xf8W07SKNcpWpUmCCEapNfNDA78dYVLcqS0EXeSYqimaf4JcW0UsVut/FG3/ANhv+Nc0EA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@aculab-com/aculab-webrtc/-/aculab-webrtc-4.0.1.tgz",
+      "integrity": "sha512-rxaVfCBOoe5MHeULKTfoq1OfAoCYMxDllnAJQpsonrotY/mxRrUUvCi1Iox5T+PduvPZc9S6TR/yIdsIgu74+Q==",
       "dependencies": {
         "sip.js": "^0.21.2",
         "source-map-loader": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aculab-com/react-native-aculab-client",
-  "version": "1.5.2-beta",
+  "version": "1.5.3",
   "description": "Aculab client for react native applications",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -162,7 +162,7 @@
     ]
   },
   "dependencies": {
-    "@aculab-com/aculab-webrtc": "^4.0.0-beta",
+    "@aculab-com/aculab-webrtc": "^4.0.1",
     "react-native-base64": "^0.2.1",
     "react-native-webrtc": "^106.0.6"
   }


### PR DESCRIPTION
Bumped versions:
react-native-aculab-client: v1.5.3
aculab-webrtc: v4.0.1